### PR TITLE
Add `rust-toolchain` to fix build

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,15 @@
-nightly
+[channel]
+nightly = "2022-12-18"
+
+[target.'cfg(any(wasm32-unknown-unknown))']
+rustc = "nightly-2022-12-18"
+
+[components]
+rustfmt = { version = "nightly-2022-12-18", features = [] }
+
+[toolchain]
+channel = "nightly-2022-12-18"
+profile = "minimal"
+
+[tool.rustup]
+version = "1.25.1"


### PR DESCRIPTION
Adds `rust-toolchain` file used in [halo2-zk-email](https://github.com/zkemail/halo2-zk-email) to fix `cargo build`.